### PR TITLE
Adding type dom-text-numeric custom data source.

### DIFF
--- a/sorting/custom-data-source/dom-text-numeric.js
+++ b/sorting/custom-data-source/dom-text-numeric.js
@@ -1,0 +1,16 @@
+/**
+ * Read information from a column of input (type number) elements and return an
+ * array to use as a basis for sorting.
+ *
+ *  @summary Sorting based on the values of `dt-tag input` elements in a column.
+ *  @name Input element data source
+ *  @requires DataTables 1.10+
+ *  @author [Allan Jardine](http://sprymedia.co.uk)
+ */
+
+$.fn.dataTable.ext.order['dom-text-numeric'] = function  ( settings, col )
+{
+    return this.api().column( col, {order:'index'} ).nodes().map( function ( td, i ) {
+        return $('input', td).val() * 1;
+    } );
+}


### PR DESCRIPTION
The [example page in DataTables documentation](https://datatables.net/examples/plug-ins/dom_sort.html) includes custom data source type called "dom-text-numeric".

When I tried to pull in the dom-text-numeric custom data source type from this package, I couldn't find it. It's a useful custom data source type, and it would be nice to have it in version control...